### PR TITLE
Added token reissue function and added logout logic

### DIFF
--- a/src/main/java/com/real_estate/llk_server_spring/security/config/SecurityConfig.java
+++ b/src/main/java/com/real_estate/llk_server_spring/security/config/SecurityConfig.java
@@ -48,7 +48,7 @@ public class SecurityConfig {
         http.httpBasic((httpBasic) -> httpBasic.disable());
         http.authorizeHttpRequests((req)->
                     req
-                            .requestMatchers("/join").permitAll()
+                            .requestMatchers("/join","/reissue").permitAll()
                             .anyRequest().authenticated()
                 );
         http.cors((cors) ->

--- a/src/main/java/com/real_estate/llk_server_spring/security/config/SecurityConfig.java
+++ b/src/main/java/com/real_estate/llk_server_spring/security/config/SecurityConfig.java
@@ -1,6 +1,7 @@
 package com.real_estate.llk_server_spring.security.config;
 
 import com.real_estate.llk_server_spring.security.entity.RefreshRepository;
+import com.real_estate.llk_server_spring.security.filter.CustomLogoutFilter;
 import com.real_estate.llk_server_spring.security.filter.JWTFilter;
 import com.real_estate.llk_server_spring.security.filter.LoginFilter;
 import com.real_estate.llk_server_spring.security.jwt.JWTUtil;
@@ -17,6 +18,7 @@ import org.springframework.security.crypto.bcrypt.BCryptPasswordEncoder;
 import org.springframework.security.crypto.password.PasswordEncoder;
 import org.springframework.security.web.SecurityFilterChain;
 import org.springframework.security.web.authentication.UsernamePasswordAuthenticationFilter;
+import org.springframework.security.web.authentication.logout.LogoutFilter;
 import org.springframework.web.cors.CorsConfiguration;
 import org.springframework.web.cors.CorsConfigurationSource;
 
@@ -70,6 +72,7 @@ public class SecurityConfig {
                     session.sessionCreationPolicy(SessionCreationPolicy.STATELESS)
                 );
         http.addFilterBefore(new JWTFilter(util), LoginFilter.class);
+        http.addFilterBefore(new CustomLogoutFilter(util,refreshRepository), LogoutFilter.class);
         http.addFilterAt(new LoginFilter(authenticationManager(authenticationConfiguration),util,refreshRepository), UsernamePasswordAuthenticationFilter.class);
         return http.build();
     }

--- a/src/main/java/com/real_estate/llk_server_spring/security/controller/ReissueController.java
+++ b/src/main/java/com/real_estate/llk_server_spring/security/controller/ReissueController.java
@@ -1,0 +1,92 @@
+package com.real_estate.llk_server_spring.security.controller;
+
+import com.real_estate.llk_server_spring.security.entity.Refresh;
+import com.real_estate.llk_server_spring.security.entity.RefreshRepository;
+import com.real_estate.llk_server_spring.security.jwt.JWTUtil;
+import io.jsonwebtoken.ExpiredJwtException;
+import jakarta.servlet.http.Cookie;
+import jakarta.servlet.http.HttpServletRequest;
+import jakarta.servlet.http.HttpServletResponse;
+import lombok.RequiredArgsConstructor;
+import org.springframework.http.HttpStatus;
+import org.springframework.http.ResponseEntity;
+import org.springframework.web.bind.annotation.PostMapping;
+import org.springframework.web.bind.annotation.RestController;
+
+import java.util.Date;
+
+@RestController
+@RequiredArgsConstructor
+public class ReissueController {
+    private final JWTUtil util;
+    private final RefreshRepository refreshRepository;
+
+    @PostMapping("/reissue")
+    public ResponseEntity<?> reissue(HttpServletRequest req, HttpServletResponse res) {
+        String refresh = null;
+
+        Cookie[] cookies = req.getCookies();
+        for (Cookie cookie : cookies) {
+            if (cookie.getName().equals("Refresh")) {
+                refresh = cookie.getValue();
+            }
+        }
+
+        if (refresh == null) {
+            return ResponseEntity.status(HttpStatus.BAD_REQUEST).body("Refresh token is null");
+        }
+
+        try {
+            util.isExpired(refresh);
+        } catch (ExpiredJwtException e) {
+            return ResponseEntity.status(HttpStatus.BAD_REQUEST).body("Refresh token is expired");
+        }
+
+        String category = util.getCategory(refresh);
+        if(!category.equals("Refresh")) {
+            return ResponseEntity.status(HttpStatus.BAD_REQUEST).body("Refresh token is invalid");
+        }
+
+        Boolean isExist = refreshRepository.existsByRefresh(refresh);
+        if(!isExist) {
+            return ResponseEntity.status(HttpStatus.BAD_REQUEST).body("Refresh token is invalid");
+        }
+
+        String username = util.getUsername(refresh);
+        String role = util.getRole(refresh);
+
+        String newAccess = util.createJwt("Access",username,role,6000L);
+        String newRefresh = util.createJwt("Refresh",username,role,60000L);
+
+        refreshRepository.deleteByRefresh(refresh);
+        addRefreshEntity(username,newRefresh,60000L);
+
+        res.addHeader("Access", newAccess);
+        res.addCookie(createCookie("Refresh",newRefresh));
+
+        return ResponseEntity.ok().body("Refresh successful");
+    }
+
+    private Cookie createCookie(String key, String value) {
+
+        Cookie cookie = new Cookie(key, value);
+        cookie.setMaxAge(24*60*60);
+        cookie.setSecure(true);
+        cookie.setPath("/");
+        cookie.setHttpOnly(true);
+
+        return cookie;
+    }
+
+    private void addRefreshEntity(String username, String refresh, Long expiredMs) {
+
+        Date date = new Date(System.currentTimeMillis() + expiredMs);
+
+        Refresh refreshEntity = new Refresh();
+        refreshEntity.setUsername(username);
+        refreshEntity.setRefresh(refresh);
+        refreshEntity.setExpiration(date.toString());
+
+        refreshRepository.save(refreshEntity);
+    }
+}

--- a/src/main/java/com/real_estate/llk_server_spring/security/entity/RefreshRepository.java
+++ b/src/main/java/com/real_estate/llk_server_spring/security/entity/RefreshRepository.java
@@ -3,4 +3,7 @@ package com.real_estate.llk_server_spring.security.entity;
 import org.springframework.data.jpa.repository.JpaRepository;
 
 public interface RefreshRepository extends JpaRepository<Refresh, Long> {
+    boolean existsByRefresh(String refresh);
+
+    long deleteByRefresh(String refresh);
 }

--- a/src/main/java/com/real_estate/llk_server_spring/security/entity/RefreshRepository.java
+++ b/src/main/java/com/real_estate/llk_server_spring/security/entity/RefreshRepository.java
@@ -1,9 +1,10 @@
 package com.real_estate.llk_server_spring.security.entity;
 
 import org.springframework.data.jpa.repository.JpaRepository;
+import org.springframework.transaction.annotation.Transactional;
 
 public interface RefreshRepository extends JpaRepository<Refresh, Long> {
     boolean existsByRefresh(String refresh);
-
-    long deleteByRefresh(String refresh);
+    @Transactional
+    void deleteByRefresh(String refresh);
 }

--- a/src/main/java/com/real_estate/llk_server_spring/security/filter/CustomLogoutFilter.java
+++ b/src/main/java/com/real_estate/llk_server_spring/security/filter/CustomLogoutFilter.java
@@ -1,0 +1,91 @@
+package com.real_estate.llk_server_spring.security.filter;
+
+import com.real_estate.llk_server_spring.security.entity.RefreshRepository;
+import com.real_estate.llk_server_spring.security.jwt.JWTUtil;
+import io.jsonwebtoken.ExpiredJwtException;
+import jakarta.servlet.FilterChain;
+import jakarta.servlet.ServletException;
+import jakarta.servlet.ServletRequest;
+import jakarta.servlet.ServletResponse;
+import jakarta.servlet.http.Cookie;
+import jakarta.servlet.http.HttpServletRequest;
+import jakarta.servlet.http.HttpServletResponse;
+import lombok.RequiredArgsConstructor;
+import org.springframework.web.filter.GenericFilterBean;
+
+import java.io.IOException;
+import java.io.PrintWriter;
+
+@RequiredArgsConstructor
+public class CustomLogoutFilter extends GenericFilterBean {
+    private final JWTUtil util;
+    private final RefreshRepository refreshRepository;
+
+    @Override
+    public void doFilter(ServletRequest servletRequest, ServletResponse servletResponse, FilterChain filterChain) throws IOException, ServletException {
+        doFilter((HttpServletRequest) servletRequest, (HttpServletResponse) servletResponse, filterChain);
+    }
+
+    private void doFilter(HttpServletRequest request, HttpServletResponse response, FilterChain filterChain) throws IOException, ServletException {
+        String requestUri = request.getRequestURI();
+        if (!requestUri.matches("^\\/logout$")) {
+
+            filterChain.doFilter(request, response);
+            return;
+        }
+        String requestMethod = request.getMethod();
+        if (!requestMethod.equals("POST")) {
+
+            filterChain.doFilter(request, response);
+            return;
+        }
+
+        String refresh = null;
+        Cookie[] cookies = request.getCookies();
+        for(Cookie cookie : cookies) {
+            if(cookie.getName().equals("Refresh")) {
+                refresh = cookie.getValue();
+            }
+        }
+
+        if(refresh == null) {
+            PrintWriter out = response.getWriter();
+            out.print("Refresh token is null");
+            response.setStatus(HttpServletResponse.SC_BAD_REQUEST);
+            return;
+        }
+
+        try {
+            util.isExpired(refresh);
+        } catch (ExpiredJwtException e) {
+            PrintWriter out = response.getWriter();
+            out.print("Refresh Token Expired");
+            response.setStatus(HttpServletResponse.SC_BAD_REQUEST);
+            return;
+        }
+
+        String category = util.getCategory(refresh);
+        if(!category.equals("Refresh")) {
+            PrintWriter out = response.getWriter();
+            out.print("Invalid Refresh Token");
+            response.setStatus(HttpServletResponse.SC_BAD_REQUEST);
+            return;
+        }
+
+        boolean isExist = refreshRepository.existsByRefresh(refresh);
+        if(!isExist) {
+            PrintWriter out = response.getWriter();
+            out.print("Refresh Token Not Found");
+            response.setStatus(HttpServletResponse.SC_BAD_REQUEST);
+            return;
+        }
+
+        refreshRepository.deleteByRefresh(refresh);
+
+        Cookie cookie = new Cookie("Refresh", null);
+        cookie.setMaxAge(0);
+        cookie.setPath("/");
+        response.addCookie(cookie);
+        response.setStatus(HttpServletResponse.SC_OK);
+    }
+}

--- a/src/main/resources/application.yml
+++ b/src/main/resources/application.yml
@@ -25,6 +25,7 @@ spring:
       hibernate:
         format_sql: true
         show_sql: true
+        default_schema: ${data.schema}
     database-platform: org.hibernate.dialect.PostgreSQLDialect
   jwt:
     secret: ${jwt.secret}


### PR DESCRIPTION
A function to reissue an access token when it expires has been added. When a token expires, a 401 error occurs. If a 401 error occurs, access /reissue to reissue the token. Also, withCredentials must be set to true to access cookies from the backend, so please send a request with true.
To log out, access /logout. Additionally, since the Refresh Token expires every 10 minutes, we recommend that the user log out if there is no action for 9 minutes and 59 seconds. This is because logging out will not proceed if you log out after 10 minutes.