### PR TITLE
Add real estate logistics data server communication logic

### DIFF
--- a/build.gradle
+++ b/build.gradle
@@ -40,6 +40,9 @@ dependencies {
     implementation 'io.jsonwebtoken:jjwt-api:0.12.3'
     implementation 'io.jsonwebtoken:jjwt-impl:0.12.3'
     implementation 'io.jsonwebtoken:jjwt-jackson:0.12.3'
+
+    // aws s3
+    implementation 'org.springframework.cloud:spring-cloud-starter-aws:2.2.6.RELEASE'
 }
 
 tasks.named('test') {

--- a/src/main/java/com/real_estate/llk_server_spring/Product/Entity/Product.java
+++ b/src/main/java/com/real_estate/llk_server_spring/Product/Entity/Product.java
@@ -3,18 +3,19 @@ package com.real_estate.llk_server_spring.Product.Entity;
 import com.real_estate.llk_server_spring.user.entity.Agent;
 import jakarta.persistence.*;
 import jakarta.validation.constraints.NotBlank;
-import jakarta.validation.constraints.Size;
-import lombok.Getter;
-import lombok.Setter;
-import org.hibernate.annotations.ColumnDefault;
+import lombok.*;
+import org.hibernate.annotations.CreationTimestamp;
+import org.hibernate.annotations.UpdateTimestamp;
 
 import java.math.BigDecimal;
 import java.time.LocalDate;
+import java.util.List;
 
 @Getter
 @Setter
 @Entity
 @Table(name = "product", schema = "db2451506_llk")
+@NoArgsConstructor @AllArgsConstructor @Builder
 public class Product {
     @Id
     @GeneratedValue(strategy = GenerationType.IDENTITY)
@@ -22,47 +23,49 @@ public class Product {
     private Long id;
 
     @NotBlank
-    @Column(name = "product_name")
+    @Column(name = "product_name", nullable = false)
     private String productName;
 
-    @Column(name = "product_description")
+    @Column(name = "product_description", nullable = false)
     private String productDescription;
 
-    @Column(name = "product_price")
+    @Column(name = "product_price", nullable = false, scale = 2)
     private BigDecimal productPrice;
 
     @NotBlank
-    @Column(name = "product_add")
+    @Column(name = "product_add", nullable = false)
     private String productAdd;
 
-    @Column(name = "product_type")
+    @Column(name = "product_type", nullable = false)
     @Enumerated(EnumType.STRING)
     private ProductType productType;
 
-    @Column(name = "product_area")
+    @Column(name = "product_area", scale = 1, precision = 10, nullable = false)
     private BigDecimal productArea;
 
-    @Column(name = "product_room")
+    @Column(name = "product_room", nullable = false)
     private Integer productRoom;
 
-    @Column(name = "product_bathroom")
+    @Column(name = "product_bathroom", nullable = false)
     private Integer productBathroom;
 
-    @Column(name = "product_year")
+    @Column(name = "product_year", nullable = false)
     private LocalDate productYear;
 
-    @Column(name = "product_img")
-    private String productImg;
-
-    @Column(name = "product_reg")
+    @Column(name = "product_reg", nullable = false, updatable = false)
+    @CreationTimestamp
     private LocalDate productReg;
 
-    @Column(name = "product_cor")
+    @Column(name = "product_cor", nullable = false)
+    @UpdateTimestamp
     private LocalDate productCor;
 
-    @Column(name = "product_sale")
+    @Column(name = "product_sale", nullable = false)
     @Enumerated(EnumType.STRING)
     private ProductSale productSale;
+
+    @OneToMany(mappedBy = "product", cascade = CascadeType.ALL, orphanRemoval = true)
+    private List<ProductImgLinkList> productImgLinkList;
 
     @JoinColumn(name = "agent_id")
     @ManyToOne(fetch = FetchType.LAZY)

--- a/src/main/java/com/real_estate/llk_server_spring/Product/Entity/Product.java
+++ b/src/main/java/com/real_estate/llk_server_spring/Product/Entity/Product.java
@@ -26,7 +26,7 @@ public class Product {
     @Column(name = "product_name", nullable = false)
     private String productName;
 
-    @Column(name = "product_description", nullable = false)
+    @Column(name = "product_description", nullable = false, columnDefinition = "TEXT")
     private String productDescription;
 
     @Column(name = "product_price", nullable = false, scale = 2)

--- a/src/main/java/com/real_estate/llk_server_spring/Product/Entity/ProductImgLinkList.java
+++ b/src/main/java/com/real_estate/llk_server_spring/Product/Entity/ProductImgLinkList.java
@@ -1,0 +1,26 @@
+package com.real_estate.llk_server_spring.Product.Entity;
+
+import jakarta.persistence.*;
+import lombok.AllArgsConstructor;
+import lombok.Getter;
+import lombok.NoArgsConstructor;
+import lombok.Setter;
+
+@Entity
+@Table(name = "product_img_link_list")
+@Getter @Setter
+@NoArgsConstructor @AllArgsConstructor
+public class ProductImgLinkList {
+    @Id
+    @GeneratedValue(strategy = GenerationType.IDENTITY)
+    @Column(name = "product_img_link_list_id")
+    private Long id;
+
+    @Column(name = "img_link")
+    private String imgLink;
+
+    @ManyToOne(fetch = FetchType.LAZY)
+    @JoinColumn(name = "product_id")
+    private Product product;
+
+}

--- a/src/main/java/com/real_estate/llk_server_spring/Product/Entity/ProductImgLinkListRepository.java
+++ b/src/main/java/com/real_estate/llk_server_spring/Product/Entity/ProductImgLinkListRepository.java
@@ -2,6 +2,5 @@ package com.real_estate.llk_server_spring.Product.Entity;
 
 import org.springframework.data.jpa.repository.JpaRepository;
 
-public interface ProductRepository extends JpaRepository<Product, Long> {
-
+public interface ProductImgLinkListRepository extends JpaRepository<ProductImgLinkList, Long> {
 }

--- a/src/main/java/com/real_estate/llk_server_spring/Product/Entity/ProductSale.java
+++ b/src/main/java/com/real_estate/llk_server_spring/Product/Entity/ProductSale.java
@@ -1,18 +1,13 @@
 package com.real_estate.llk_server_spring.Product.Entity;
 
+import lombok.AllArgsConstructor;
+import lombok.Getter;
+
+@Getter
+@AllArgsConstructor
 public enum ProductSale {
     SALE("SALE", "판매중"), SOLD_OUT("SOLD_OUT", "판매 완료");
 
     private final String eng;
     private final String kor;
-    private ProductSale(String eng, String kor) {
-        this.eng = eng;
-        this.kor = kor;
-    }
-    public String getEng() {
-        return eng;
-    }
-    public String getKor() {
-        return kor;
-    }
 }

--- a/src/main/java/com/real_estate/llk_server_spring/Product/Entity/ProductType.java
+++ b/src/main/java/com/real_estate/llk_server_spring/Product/Entity/ProductType.java
@@ -1,20 +1,15 @@
 package com.real_estate.llk_server_spring.Product.Entity;
 
+
+import lombok.AllArgsConstructor;
+import lombok.Getter;
+
+@Getter
+@AllArgsConstructor
 public enum ProductType {
     APARTMENT("APARTMENT", "아파트"), HOUSE("HOUSE","주택"),
     COMMERCIAL_LAND("COMMERCIAL LAND", "상업용 토지"), ETC("ETC", "기타");
 
     private final String eng;
     private final String kor;
-
-    private ProductType(String eng, String kor) {
-        this.eng = eng;
-        this.kor = kor;
-    }
-    public String getEng() {
-        return eng;
-    }
-    public String getKor() {
-        return kor;
-    }
 }

--- a/src/main/java/com/real_estate/llk_server_spring/Product/ProductController.java
+++ b/src/main/java/com/real_estate/llk_server_spring/Product/ProductController.java
@@ -1,13 +1,12 @@
 package com.real_estate.llk_server_spring.Product;
 
-import com.real_estate.llk_server_spring.Product.Entity.Product;
 import com.real_estate.llk_server_spring.Product.dto.ProjectDTO;
 import lombok.RequiredArgsConstructor;
 import org.springframework.http.ResponseEntity;
-import org.springframework.web.bind.annotation.PostMapping;
-import org.springframework.web.bind.annotation.RequestBody;
-import org.springframework.web.bind.annotation.RequestMapping;
-import org.springframework.web.bind.annotation.RestController;
+import org.springframework.web.bind.annotation.*;
+import org.springframework.web.multipart.MultipartFile;
+
+import java.util.List;
 
 @RestController
 @RequestMapping("/products")
@@ -16,8 +15,13 @@ public class ProductController {
     private final ProductService productService;
 
     @PostMapping("/add")
-    public ResponseEntity<Product> createProduct(@RequestBody ProjectDTO projectDTO) {
-        Product createProduct = productService.createProduct(projectDTO);
-        return ResponseEntity.ok(createProduct);
+    public ResponseEntity<?> createProduct(@RequestPart(value = "data") ProjectDTO projectDTO,
+                                                 @RequestPart(name = "file") List<MultipartFile> files) {
+        return productService.createProductProc(projectDTO, files);
+    }
+
+    @PostMapping("/delete")
+    public ResponseEntity<?> deleteProduct(@RequestBody String id) {
+        return productService.deleteProductProc(id);
     }
 }

--- a/src/main/java/com/real_estate/llk_server_spring/Product/ProductService.java
+++ b/src/main/java/com/real_estate/llk_server_spring/Product/ProductService.java
@@ -1,33 +1,66 @@
 package com.real_estate.llk_server_spring.Product;
 
+import com.amazonaws.services.s3.AmazonS3Client;
 import com.real_estate.llk_server_spring.Product.Entity.Product;
 import com.real_estate.llk_server_spring.Product.Entity.ProductRepository;
-import com.real_estate.llk_server_spring.Product.Entity.ProductSale;
-import com.real_estate.llk_server_spring.Product.Entity.ProductType;
 import com.real_estate.llk_server_spring.Product.dto.ProjectDTO;
+import com.real_estate.llk_server_spring.exception.LlkServerException;
+import com.real_estate.llk_server_spring.util.LlkUtil;
 import lombok.RequiredArgsConstructor;
+import org.springframework.beans.factory.annotation.Value;
+import org.springframework.http.HttpStatus;
+import org.springframework.http.ResponseEntity;
 import org.springframework.stereotype.Service;
+import org.springframework.web.multipart.MultipartFile;
+
+import java.math.BigDecimal;
+import java.util.List;
 
 @Service
 @RequiredArgsConstructor
 public class ProductService {
     private final ProductRepository productRepository;
+    private final LlkUtil llkUtil;
+    private final AmazonS3Client amazonS3Client;
+    @Value("${s3.bucket-name}")
+    private String bucketName;
 
-    public Product createProduct(ProjectDTO projectDTO) {
-        Product product = new Product();
-        product.setProductName(projectDTO.getName());
-        product.setProductDescription(projectDTO.getDescription());
-        product.setProductPrice(projectDTO.getPrice());
-        product.setProductAdd(projectDTO.getAdd());
-        product.setProductType(ProductType.APARTMENT);
-        product.setProductArea(projectDTO.getArea());
-        product.setProductRoom(projectDTO.getRoom());
-        product.setProductBathroom(projectDTO.getBathroom());
-        product.setProductYear(projectDTO.getYear());
-        product.setProductImg(projectDTO.getImg());
-        product.setProductReg(projectDTO.getReg());
-        product.setProductCor(projectDTO.getCor());
-        product.setProductSale(ProductSale.SALE);
-        return productRepository.save(product);
+    public ResponseEntity<?> createProductProc(ProjectDTO projectDTO, List<MultipartFile> files) {
+        try {
+            llkUtil.usingStringDataValidationCheck(projectDTO.getName());
+            llkUtil.usingStringDataValidationCheck(projectDTO.getDescription());
+            llkUtil.usingStringDataValidationCheck(String.valueOf(projectDTO.getPrice()));
+            llkUtil.usingStringDataValidationCheck(projectDTO.getAdd());
+            llkUtil.usingStringDataValidationCheck(String.valueOf(projectDTO.getType()));
+            llkUtil.usingStringDataValidationCheck(String.valueOf(projectDTO.getArea()));
+            llkUtil.usingStringDataValidationCheck(String.valueOf(projectDTO.getRoom()));
+            llkUtil.usingStringDataValidationCheck(String.valueOf(projectDTO.getBathroom()));
+            llkUtil.usingStringDataValidationCheck(String.valueOf(projectDTO.getYear()));
+            llkUtil.usingStringDataValidationCheck(String.valueOf(projectDTO.getSale()));
+            llkUtil.usingStringDataValidationCheck(files.toString());
+        } catch (LlkServerException e) {
+            return new ResponseEntity<>(e.getMessage(), HttpStatus.BAD_REQUEST);
+        }
+        // img file upload logic
+        Product product = new Product().builder()
+                .productName(projectDTO.getName())
+                .productDescription(projectDTO.getDescription())
+                .productPrice(BigDecimal.valueOf(projectDTO.getPrice()))
+                .productAdd(projectDTO.getAdd())
+                .productType(projectDTO.getType())
+                .productArea(BigDecimal.valueOf(projectDTO.getArea()))
+                .productRoom(projectDTO.getRoom())
+                .productBathroom(projectDTO.getBathroom())
+                .productYear(projectDTO.getYear())
+                .productSale(projectDTO.getSale())
+                .build();
+        productRepository.save(product);
+        llkUtil.imgFileUploadProc(files,product,"hojung");
+
+        return ResponseEntity.status(HttpStatus.CREATED).body("product created successfully");
+    }
+
+    public ResponseEntity<?> deleteProductProc(String id) {
+        return null;
     }
 }

--- a/src/main/java/com/real_estate/llk_server_spring/Product/ProductService.java
+++ b/src/main/java/com/real_estate/llk_server_spring/Product/ProductService.java
@@ -1,13 +1,11 @@
 package com.real_estate.llk_server_spring.Product;
 
-import com.amazonaws.services.s3.AmazonS3Client;
 import com.real_estate.llk_server_spring.Product.Entity.Product;
 import com.real_estate.llk_server_spring.Product.Entity.ProductRepository;
 import com.real_estate.llk_server_spring.Product.dto.ProjectDTO;
 import com.real_estate.llk_server_spring.exception.LlkServerException;
 import com.real_estate.llk_server_spring.util.LlkUtil;
 import lombok.RequiredArgsConstructor;
-import org.springframework.beans.factory.annotation.Value;
 import org.springframework.http.HttpStatus;
 import org.springframework.http.ResponseEntity;
 import org.springframework.stereotype.Service;
@@ -21,9 +19,6 @@ import java.util.List;
 public class ProductService {
     private final ProductRepository productRepository;
     private final LlkUtil llkUtil;
-    private final AmazonS3Client amazonS3Client;
-    @Value("${s3.bucket-name}")
-    private String bucketName;
 
     public ResponseEntity<?> createProductProc(ProjectDTO projectDTO, List<MultipartFile> files) {
         try {

--- a/src/main/java/com/real_estate/llk_server_spring/Product/dto/ProjectDTO.java
+++ b/src/main/java/com/real_estate/llk_server_spring/Product/dto/ProjectDTO.java
@@ -1,26 +1,22 @@
 package com.real_estate.llk_server_spring.Product.dto;
 
+import com.real_estate.llk_server_spring.Product.Entity.ProductSale;
+import com.real_estate.llk_server_spring.Product.Entity.ProductType;
 import lombok.Getter;
 import lombok.Setter;
 
-import java.math.BigDecimal;
 import java.time.LocalDate;
-import java.util.Date;
 
 @Getter @Setter
 public class ProjectDTO {
     private String name;
     private String description;
-    private BigDecimal price;
+    private Float price;
     private String add;
-    private String type;
-    private BigDecimal area;
+    private ProductType type;
+    private Float area;
     private Integer room;
     private Integer bathroom;
     private LocalDate year;
-    private String img;
-    private LocalDate reg;
-    private LocalDate cor;
-    private String sale;
-    private Integer count;
+    private ProductSale sale;
 }

--- a/src/main/java/com/real_estate/llk_server_spring/exception/LlkServerExceptionErrorCode.java
+++ b/src/main/java/com/real_estate/llk_server_spring/exception/LlkServerExceptionErrorCode.java
@@ -10,7 +10,8 @@ import lombok.RequiredArgsConstructor;
 public enum LlkServerExceptionErrorCode {
     NOT_FOUNT_AGENT("001_LLK","LLK real estate agent information not found."),
     NOT_FOUNT_REVIEW("002_LLK","LLK real estate review information not found."),
-    DONT_REQUEST_DATA("003_LLK","LLK request data not found."),;
+    DONT_REQUEST_DATA("003_LLK","LLK request data not found."),
+    FALE_IMG_CONVERT("004_LLK","LLK img file convert failed."),;
 
     private String errorCode;
     private String errorMessage;

--- a/src/main/java/com/real_estate/llk_server_spring/review/entity/Review.java
+++ b/src/main/java/com/real_estate/llk_server_spring/review/entity/Review.java
@@ -27,7 +27,7 @@ public class Review {
     @Column(name = "review_name", nullable = false)
     private String reviewName;
 
-    @Column(name = "review_description", nullable = false)
+    @Column(name = "review_description", nullable = false, columnDefinition = "TEXT")
     private String reviewDescription;
 
     @Column(name = "address", nullable = false)

--- a/src/main/java/com/real_estate/llk_server_spring/s3/S3Config.java
+++ b/src/main/java/com/real_estate/llk_server_spring/s3/S3Config.java
@@ -1,0 +1,31 @@
+package com.real_estate.llk_server_spring.s3;
+
+import com.amazonaws.auth.AWSStaticCredentialsProvider;
+import com.amazonaws.auth.BasicAWSCredentials;
+import com.amazonaws.services.s3.AmazonS3Client;
+import com.amazonaws.services.s3.AmazonS3ClientBuilder;
+import org.springframework.beans.factory.annotation.Value;
+import org.springframework.context.annotation.Bean;
+import org.springframework.context.annotation.Configuration;
+
+@Configuration
+public class S3Config {
+
+    @Value("${aws.cloud.credentials.access-key}")
+    private String accessKey;
+
+    @Value("${aws.cloud.credentials.secret-key}")
+    private String secretKey;
+
+    @Value("${aws.cloud.region.static}")
+    private String region;
+
+    @Bean
+    public AmazonS3Client amazonS3Client() {
+        BasicAWSCredentials awsCredentials= new BasicAWSCredentials(accessKey, secretKey);
+        return (AmazonS3Client)AmazonS3ClientBuilder.standard()
+                .withRegion(region)
+                .withCredentials(new AWSStaticCredentialsProvider(awsCredentials))
+                .build();
+    }
+}

--- a/src/main/java/com/real_estate/llk_server_spring/security/config/SecurityConfig.java
+++ b/src/main/java/com/real_estate/llk_server_spring/security/config/SecurityConfig.java
@@ -18,7 +18,6 @@ import org.springframework.security.config.annotation.web.configuration.EnableWe
 import org.springframework.security.config.http.SessionCreationPolicy;
 import org.springframework.security.crypto.bcrypt.BCryptPasswordEncoder;
 import org.springframework.security.crypto.password.PasswordEncoder;
-import org.springframework.security.oauth2.client.web.OAuth2LoginAuthenticationFilter;
 import org.springframework.security.web.SecurityFilterChain;
 import org.springframework.security.web.authentication.UsernamePasswordAuthenticationFilter;
 import org.springframework.security.web.authentication.logout.LogoutFilter;
@@ -58,7 +57,7 @@ public class SecurityConfig {
                             .requestMatchers("/join","/reissue","/products/**","/availability/email",
                                     "/contact","/review/list").permitAll()
                             .requestMatchers("/review/add").hasAnyRole("USER","ADMIN","AGENT")
-                            .requestMatchers("/admin/user/**").hasRole("ADMIN")
+                            .requestMatchers("/admin/user/**", "/products/add").hasRole("ADMIN")
                             .anyRequest().authenticated()
                 );
         http.cors((cors) ->

--- a/src/main/java/com/real_estate/llk_server_spring/util/LlkUtil.java
+++ b/src/main/java/com/real_estate/llk_server_spring/util/LlkUtil.java
@@ -1,10 +1,16 @@
 package com.real_estate.llk_server_spring.util;
 
+import com.amazonaws.services.s3.AmazonS3Client;
+import com.amazonaws.services.s3.model.CannedAccessControlList;
+import com.amazonaws.services.s3.model.DeleteObjectRequest;
+import com.amazonaws.services.s3.model.PutObjectRequest;
+import com.real_estate.llk_server_spring.Product.Entity.Product;
+import com.real_estate.llk_server_spring.Product.Entity.ProductImgLinkList;
+import com.real_estate.llk_server_spring.Product.Entity.ProductImgLinkListRepository;
 import com.real_estate.llk_server_spring.exception.LlkServerException;
 import com.real_estate.llk_server_spring.exception.LlkServerExceptionErrorCode;
 import com.real_estate.llk_server_spring.review.entity.Review;
 import com.real_estate.llk_server_spring.review.entity.ReviewRepository;
-import com.real_estate.llk_server_spring.review.entity.ReviewType;
 import com.real_estate.llk_server_spring.security.jwt.JWTUtil;
 import com.real_estate.llk_server_spring.user.entity.Agent;
 import com.real_estate.llk_server_spring.user.entity.AgentRepository;
@@ -12,11 +18,20 @@ import com.real_estate.llk_server_spring.user.entity.UserRepository;
 import com.real_estate.llk_server_spring.user.entity.Users;
 import jakarta.servlet.http.HttpServletRequest;
 import lombok.RequiredArgsConstructor;
+import org.apache.logging.log4j.LogManager;
+import org.apache.logging.log4j.Logger;
+import org.springframework.beans.factory.annotation.Value;
 import org.springframework.http.HttpStatus;
-import org.springframework.http.ResponseEntity;
 import org.springframework.stereotype.Component;
+import org.springframework.web.multipart.MultipartFile;
 
+import java.io.File;
+import java.io.FileOutputStream;
+import java.io.IOException;
+import java.util.ArrayList;
 import java.util.List;
+import java.util.Optional;
+import java.util.UUID;
 
 @Component
 @RequiredArgsConstructor
@@ -25,6 +40,12 @@ public class LlkUtil {
     private final UserRepository userRepository;
     private final AgentRepository agentRepository;
     private final ReviewRepository reviewRepository;
+    private final ProductImgLinkListRepository productImgLinkListRepository;
+    private final AmazonS3Client amazonS3Client;
+
+    @Value("${s3.bucket-name}")
+    private String bucketName;
+    private static final Logger logger = LogManager.getLogger(LlkUtil.class);
 
     public String usingRequestGetEmail(HttpServletRequest req) {
         String access = req.getHeader("Access");
@@ -49,5 +70,74 @@ public class LlkUtil {
         if (str == null || str.isEmpty()) {
             throw new LlkServerException(HttpStatus.BAD_REQUEST,LlkServerExceptionErrorCode.DONT_REQUEST_DATA);
         }
+    }
+
+    public void imgFileUploadProc(List<MultipartFile> fileList, Product product, String dirName) {
+        try {
+            List<ProductImgLinkList> productImgLinkLists = new ArrayList<>();
+            for (MultipartFile file : fileList) {
+                if(file != null) {
+                    File uploadFile = convert(file)
+                            .orElseThrow(() -> new LlkServerException(HttpStatus.INTERNAL_SERVER_ERROR,LlkServerExceptionErrorCode.FALE_IMG_CONVERT));
+                    ProductImgLinkList productImgLinkList = new ProductImgLinkList();
+                    productImgLinkList.setImgLink(upload(uploadFile, dirName));
+                    productImgLinkList.setProduct(product);
+                    productImgLinkLists.add(productImgLinkList);
+                    productImgLinkListRepository.save(productImgLinkList);
+                }
+            }
+        } catch (LlkServerException e) {
+            throw new LlkServerException(HttpStatus.INTERNAL_SERVER_ERROR, LlkServerExceptionErrorCode.FALE_IMG_CONVERT);
+        }
+    }
+
+    // S3로 파일 업로드하기
+    private String upload(File uploadFile, String dirName) {
+        String fileName = dirName + "/" + UUID.randomUUID(); // S3에 저장된 파일 이름
+        String uploadImageUrl = putS3(uploadFile, fileName); // s3로 업로드
+        removeNewFile(uploadFile); // 로컬에 저장된 File 삭제
+        return uploadImageUrl;
+    }
+
+    // S3로 업로드
+    private String putS3(File uploadFile, String fileName) {
+        amazonS3Client.putObject(new PutObjectRequest(bucketName, fileName, uploadFile).withCannedAcl(CannedAccessControlList.PublicRead));
+        return amazonS3Client.getUrl(bucketName, fileName).toString();
+    }
+
+
+    // 로컬에 저장된 이미지 지우기
+    private void removeNewFile(File targetFile) {
+        if (targetFile.delete()) {
+            logger.info("Local:File delete success");
+            return;
+        }
+        logger.info("Local: File delete fail");
+    }
+
+    //이미지 변환과정
+    private Optional<File> convert(MultipartFile multipartFile) {
+        try {
+            File convertFile = new File(multipartFile.getOriginalFilename());
+            // 바로 위에서 지정한 경로에 File이 생성됨 (경로가 잘못되었다면 생성 불가능)
+            if (convertFile.createNewFile()) {
+                try (FileOutputStream fos = new FileOutputStream(convertFile)) { // FileOutputStream 데이터를 파일에 바이트 스트림으로 저장하기 위함
+                    fos.write(multipartFile.getBytes());
+                }
+                return Optional.of(convertFile);
+            }
+        } catch (IOException | LlkServerException e) {
+            throw new LlkServerException(HttpStatus.INTERNAL_SERVER_ERROR, LlkServerExceptionErrorCode.FALE_IMG_CONVERT);
+        }
+
+        return Optional.empty();
+    }
+
+    //s3 이미지 삭제
+    public void deleteFile(String filename) {
+        System.out.println("delete filename = " + filename);
+        amazonS3Client.deleteObject(new DeleteObjectRequest(bucketName, filename));
+        System.out.println(String.format("[%s] deletion complete", filename));
+
     }
 }

--- a/src/main/resources/application.yml
+++ b/src/main/resources/application.yml
@@ -15,7 +15,7 @@ spring:
     password: ${data.password}
     driver-class-name: org.postgresql.Driver
   config:
-    import: classpath:jwt.yml, classpath:database.yml, classpath:google-oauth2.yml
+    import: classpath:jwt.yml, classpath:database.yml, classpath:google-oauth2.yml, classpath:aws-s3.yml
   jpa:
     hibernate:
       ddl-auto: update
@@ -39,6 +39,10 @@ spring:
             scope:
               - profile
               - email
+  servlet:
+    multipart:
+      max-file-size: 50MB
+      max-request-size: 50MB
 
 logging:
   level:
@@ -49,3 +53,23 @@ logging:
       springframework:
         security: debug
     root: info
+
+#google:
+#  cloud:
+#    translation:
+#      credentials:
+#        file:
+#          path: ${google.translation.json-key}
+
+aws:
+  cloud:
+    s3:
+      bucket: ${s3.bucket-name}
+    region:
+      static: ${s3.region}
+      auto: false
+    stack:
+      auto: false
+    credentials:
+      access-key: ${s3.access-key}
+      secret-key: ${s3.secret-key}

--- a/src/main/resources/application.yml
+++ b/src/main/resources/application.yml
@@ -41,8 +41,8 @@ spring:
               - email
   servlet:
     multipart:
-      max-file-size: 50MB
-      max-request-size: 50MB
+      max-file-size: 100MB
+      max-request-size: 1GB
 
 logging:
   level:


### PR DESCRIPTION
EN : When transferring data and img files from the client to the server, the logic was configured to save the real estate logistics data in the database and the image in AWS S3 on the server. Please check the next page for detailed information on communicating with the server. API document address: https://au-kr.atlassian.net/wiki/spaces/LLK/pages/154599425/Product
If you have any problems or questions, please DM me.
KR : 클라이언트에서 서버로 데이터와 img 파일을 전송시 서버에서 부동산 물류 데이터를 db에 이미지를 aws s3 에 저장 하도록 로직을 구성하였습니다. 서버와 통신을 위한 자세한 내용은 다음 페이지에서 확인을 하여 주세요. api 문서 주소 :  https://au-kr.atlassian.net/wiki/spaces/LLK/pages/154599425/Product
문제 및 질문사항이 생기시면 DM 부탁드립니다.